### PR TITLE
Version 0.2: Add ACF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Campaigns
 Wordpress Plugin to pull in campaigns from Speakout and CSL
+
+# Installation
+Can be installed through the WP plugins interface by uploading a zip of this directory.

--- a/campaigns.php
+++ b/campaigns.php
@@ -49,6 +49,7 @@ function campaigns_admin_menu() {
 function campaigns_admin_init() {
     register_setting('campaigns-settings', 'speakout_url');
     register_setting('campaigns-settings', 'csl_url');
+    register_setting('campaigns-settings', 'acf_post_type');
 }
 
 function campaigns_settings_page() {
@@ -72,6 +73,14 @@ function campaigns_settings_page() {
             <td><input type='text' name='csl_url' value="<?php echo esc_attr(get_option('csl_url')) ?>" style="width: 60%;"></td>
             </tr>
         </table>
+
+        <table class="form-table">
+            <tr valign="top">
+            <th scope="row">ACF Post Type: (Leave blank to not use ACF)</th>
+            <td><input type='text' name='acf_post_type' value="<?php echo esc_attr(get_option('acf_post_type')) ?>" style="width: 60%;"></td>
+            </tr>
+        </table>
+        <p>Note: if using ACF, ensure your chosen post type includes fields named external_id,url,source,image,actions and max_actions.</p>
 
         <?php submit_button(); ?>
       </form>

--- a/campaigns.php
+++ b/campaigns.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package Campaigns
- * @version 0.1
+ * @version 0.2
  */
 
 /*
   Plugin Name: Campaigns
   Description: Pull and lists petitions from CSL and Speakout
-  Author: Hiemanshu Sharma
-  Version: 0.1
+  Author: Hiemanshu Sharma & Frances McMullin
+  Version: 0.2
   Text Domain: campaigns
 */
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
       "name": "Hiemanshu Sharma",
       "email": "hiemanshu@the-open.net"
     }
+    {
+      "name": "Frances McMullin",
+      "email": "frances@the-open.net"
+    }
   ],
   "require": {
     "php": ">=7.2",

--- a/lib/campaign.php
+++ b/lib/campaign.php
@@ -78,35 +78,39 @@ class Campaign {
     }
 
     static public function create_post_type() {
-        register_post_type(
-            'campaign',
-            [
-                'labels' => [
-                    'name' => __('Campaigns'),
-                    'singular_name' => __('Campaign'),
-                    'add_new' => _x('Add New', 'campaign'),
-                    'add_new_item' => __('Add New Campaign'),
-                    'edit_item' => __('Edit Campaign'),
-                    'new_item' => __('New Campaign'),
-                    'view_item' => __('View Campaign'),
-                    'search_items' => __('Search Campaigns'),
-                    'not_found' =>  __('Nothing found'),
-                    'not_found_in_trash' => __('Nothing found in Trash')
-                ],
-                'description' => 'Campaigns',
-                'public' => true,
-                'show_in_menu' => true,
-                'menu_position' => 20,
-                'show_in_rest' => true,
-                'has_archive' => true,
-                'supports' => [
-                    'title',
-                    'editor',
-                    'thumbnail',
-                    'custom-fields'
+        $acf_post_type = get_option('acf_post_type');
+        $post_type = (!empty($acf_post_type) && post_type_exists($acf_post_type)) ? $acf_post_type : 'campaign';
+        if ( $post_type == 'campaign' ) {
+            register_post_type(
+                'campaign',
+                [
+                    'labels' => [
+                        'name' => __('Campaigns'),
+                        'singular_name' => __('Campaign'),
+                        'add_new' => _x('Add New', 'campaign'),
+                        'add_new_item' => __('Add New Campaign'),
+                        'edit_item' => __('Edit Campaign'),
+                        'new_item' => __('New Campaign'),
+                        'view_item' => __('View Campaign'),
+                        'search_items' => __('Search Campaigns'),
+                        'not_found' =>  __('Nothing found'),
+                        'not_found_in_trash' => __('Nothing found in Trash')
+                    ],
+                    'description' => 'Campaigns',
+                    'public' => true,
+                    'show_in_menu' => true,
+                    'menu_position' => 20,
+                    'show_in_rest' => true,
+                    'has_archive' => true,
+                    'supports' => [
+                        'title',
+                        'editor',
+                        'thumbnail',
+                        'custom-fields'
+                    ]
                 ]
-            ]
-        );
+            );
+        }
     }
 
 }

--- a/lib/campaign.php
+++ b/lib/campaign.php
@@ -41,6 +41,8 @@ class Campaign {
         ];
 
         if ( $posts->have_posts() ) {
+            // Avoid overriding admin edits to publish date or status
+            unset($post_args['post_date'], $post_args['post_status']);
             $posts->the_post();
             wp_update_post(array_merge([
                 'ID' => get_the_ID()

--- a/lib/campaign.php
+++ b/lib/campaign.php
@@ -74,6 +74,7 @@ class Campaign {
                 'public' => true,
                 'show_in_menu' => true,
                 'menu_position' => 20,
+                'show_in_rest' => true,
                 'has_archive' => true,
                 'supports' => [
                     'title',

--- a/lib/campaign.php
+++ b/lib/campaign.php
@@ -3,8 +3,14 @@
 class Campaign {
 
     static public function add_or_update($campaign_data) {
+        global $wpdb;
+        $acf_post_type = get_option('acf_post_type');
+        $post_type = (!empty($acf_post_type) && post_type_exists($acf_post_type)) ? $acf_post_type : 'campaign';
+        $post_id = 0;
+
         $posts = new WP_Query([
-            'post_type' => 'campaign',
+            'posts_per_page'    => -1,
+            'post_type' => $post_type,
             'meta_query' => [
                 'relation' => 'AND',
                 [
@@ -23,7 +29,7 @@ class Campaign {
         $post_content = (empty($campaign_data["description"])) ? "" : $campaign_data["description"];
 
         $post_args = [
-            'post_type' => 'campaign',
+            'post_type' => $post_type,
             'post_title' => $campaign_data["name"],
             'post_content' => $post_content,
             'post_status' => 'publish',
@@ -40,15 +46,32 @@ class Campaign {
             ]
         ];
 
+        // If using ACF, skip direct editing of custom  fields here and use ACF methods later
+        if ( $post_type != 'campaign' ) {
+            unset($post_args['meta_input']);
+        }
+
         if ( $posts->have_posts() ) {
             // Avoid overriding admin edits to publish date or status
             unset($post_args['post_date'], $post_args['post_status']);
             $posts->the_post();
+            $post_id = get_the_ID();
             wp_update_post(array_merge([
-                'ID' => get_the_ID()
+                'ID' => $post_id
             ], $post_args));
         } else {
-            wp_insert_post($post_args);
+            $result = wp_insert_post($post_args);
+            $post_id = $result;
+        }
+
+        // Use ACF methods to update campaign data
+        if ( $post_type != 'campaign' ) {
+            update_field('external_id', $campaign_data["external_id"], $post_id);
+            update_field('url', $campaign_data["url"], $post_id);
+            update_field('source', $campaign_data["source"], $post_id);
+            update_field('image', $campaign_data["image"], $post_id);
+            update_field('actions', $campaign_data["actions"], $post_id);
+            update_field('max_actions', $campaign_data["max_actions"], $post_id);
         }
 
         wp_reset_postdata();


### PR DESCRIPTION
Pulling in some updates made while working with Amandla. The biggest is  ACF support, implemented here through  an additional optional setting. ACF support is desireable  because it is a more widely  understood system  for use with themes and other plugins, including Elementor. By supporting ACF, it should be more straightforward to  design  custom  campaign post  layouts on campaign list and search pages.

Also includes:
- Only update post date and status on  campaign  creation - this makes it possible for WordPress admins to  adjust campaign visibility  and ordering, without the  plugin overwriting their  changes
- Set `show_in_rest: true` on the campaigns  post_type -  this  is  needed so that the custom fields will be visible/editable (only works if ACF is  not  present though!)